### PR TITLE
Add custom prefix based on language id

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
                   "markdownDescription": "Enables custom prefix string based on language identifier. Default to `wrap-console-log.format.wrap.prefixString` if language identifier is not specified.",
                   "type": "object",
                   "default": {
-                    "shellscript": "echo '$var:' $var",
+                    "shellscript": "echo '$var:' $$var",
                     "rust": "println!(\"$var: {}\", $var);",
                     "ruby": "puts \"$name: #{$name}\"",
                     "go": "fmt.Println(\"$var:\", $var)"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "type": "git",
         "url": "https://github.com/midnightsyntax/vscode-wrap-console-log"
     },
-    "version": "1.7.3",
+    "version": "1.7.4",
     "publisher": "midnightsyntax",
     "icon": "images/icon.png",
     "engines": {
@@ -109,6 +109,16 @@
                     "markdownDescription": "Enables custom control of the prefix log string. Use `$func` to specify the function name defined by [`Wrap Function Name`](#wrap-console-log.format.text.prefixFunctionName) and `$var` to specify the variable/text to log. `$var` can be specified **one** or **multible** times. ",
                     "type": "string",
                     "default": "$func('$var:', $var)"
+                },
+                "wrap-console-log.format.wrap.prefixStringLanguages": {
+                  "markdownDescription": "Enables custom prefix string based on language identifier. Default to `wrap-console-log.format.wrap.prefixString` if language identifier is not specified.",
+                  "type": "object",
+                  "default": {
+                    "shellscript": "echo '$var:' $var",
+                    "rust": "println!(\"$var: {}\", $var)",
+                    "ruby": "puts \"$name: #{$name}\"",
+                    "go": "fmt.Println(\"$var:\", $var)"
+                  }
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
                   "type": "object",
                   "default": {
                     "shellscript": "echo '$var:' $var",
-                    "rust": "println!(\"$var: {}\", $var)",
+                    "rust": "println!(\"$var: {}\", $var);",
                     "ruby": "puts \"$name: #{$name}\"",
                     "go": "fmt.Println(\"$var:\", $var)"
                   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,6 +75,7 @@ function handle(target: Wrap, prefix?: boolean, input?: boolean, formatAs?: Form
             } ;
 
             prefix = prefix || getSetting("alwaysUsePrefix") ? true : false
+            const prefixString = getSetting("format.wrap.prefixStringLanguages")[doc.languageId] || getSetting('format.wrap.prefixString');
 
             if (prefix) {
                 if (getSetting("alwaysInputBoxOnPrefix") == true || input) {
@@ -85,7 +86,7 @@ function handle(target: Wrap, prefix?: boolean, input?: boolean, formatAs?: Form
                         } else reject('INPUT_CANCEL');
                     })
                 } else {
-                    wrapData.txt = getSetting('format.wrap.prefixString').replace('$func',
+                    wrapData.txt = prefixString.replace('$func',
                                     getSetting('format.wrap.prefixFunctionName')).replace(/[$]var/g,
                                     wrapData.item);
                     resolve(wrapData);


### PR DESCRIPTION
Hey, thanks for the extension!

I love that I can wrap a variable based on current cursor (no manual selection needed) but I wanted to have similar workflow for different languages. Based on [#24](https://github.com/midnightsyntax/vscode-wrap-console-log/issues/24#issuecomment-1244485417), seems like you're working on multi language support but I thought I'd just send this PR to give context on how I'd use it.

Currently I only use wrap down prefix and the changes in this PR has worked for me. Here's a preview of the new setting (`prefixStringLanguages`) and how it's used in different files (rust, ruby, go, shell):

![wrap-console mov mp4](https://user-images.githubusercontent.com/7823011/199593164-55972481-3b08-4f44-b678-20756bc18521.gif)

Notes: I use `alt+/` to trigger `console.log.wrap.down.prefix`